### PR TITLE
Update naming in modules closes #20

### DIFF
--- a/code/appService/ARM/main.json
+++ b/code/appService/ARM/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.10.61.36676",
-      "templateHash": "7842899470013777756"
+      "templateHash": "12811466118635564704"
     }
   },
   "parameters": {
@@ -37,19 +37,14 @@
       "westus": "wus",
       "westus2": "wus2"
     },
-    "suffix": "[toLower(format('{0}-{1}-{2}', parameters('baseName'), parameters('environmentName'), variables('regionReference')[parameters('location')]))]",
-    "resourceGroupName": "[format('rg-{0}', variables('suffix'))]",
-    "appServicePlanName": "[format('asp-{0}', variables('suffix'))]",
-    "appServiceName": "[format('app-{0}', variables('suffix'))]",
-    "appInsightsName": "[format('ai-{0}', variables('suffix'))]",
-    "logAnalyticsName": "[format('la-{0}', variables('suffix'))]",
+    "nameSuffix": "[toLower(format('{0}-{1}-{2}', parameters('baseName'), parameters('environmentName'), variables('regionReference')[parameters('location')]))]",
     "language": "ARM"
   },
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2021-04-01",
-      "name": "[variables('resourceGroupName')]",
+      "name": "[toLower(format('rg-{0}', variables('nameSuffix')))]",
       "location": "[parameters('location')]",
       "tags": {
         "Customer": "FlavorsIaC",
@@ -60,7 +55,7 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "appServicePlanModule",
-      "resourceGroup": "[variables('resourceGroupName')]",
+      "resourceGroup": "[toLower(format('rg-{0}', variables('nameSuffix')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -71,7 +66,7 @@
             "value": "[parameters('location')]"
           },
           "appServicePlanName": {
-            "value": "[variables('appServicePlanName')]"
+            "value": "[variables('nameSuffix')]"
           },
           "language": {
             "value": "[variables('language')]"
@@ -84,7 +79,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.10.61.36676",
-              "templateHash": "16008645719636300553"
+              "templateHash": "8898895798000366640"
             }
           },
           "parameters": {
@@ -157,7 +152,7 @@
             {
               "type": "Microsoft.Web/serverfarms",
               "apiVersion": "2022-03-01",
-              "name": "[parameters('appServicePlanName')]",
+              "name": "[toLower(format('asp-{0}', parameters('appServicePlanName')))]",
               "location": "[parameters('location')]",
               "kind": "[parameters('appServiceKind')]",
               "sku": {
@@ -172,20 +167,20 @@
           "outputs": {
             "appServicePlanID": {
               "type": "string",
-              "value": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+              "value": "[resourceId('Microsoft.Web/serverfarms', toLower(format('asp-{0}', parameters('appServicePlanName'))))]"
             }
           }
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', toLower(format('rg-{0}', variables('nameSuffix'))))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "appServiceModule",
-      "resourceGroup": "[variables('resourceGroupName')]",
+      "resourceGroup": "[toLower(format('rg-{0}', variables('nameSuffix')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -196,13 +191,13 @@
             "value": "[parameters('location')]"
           },
           "appServicePlanID": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appServicePlanModule')).outputs.appServicePlanID.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'appServicePlanModule')).outputs.appServicePlanID.value]"
           },
           "appServiceName": {
-            "value": "[variables('appServiceName')]"
+            "value": "[variables('nameSuffix')]"
           },
           "appInsightsInstrumentationKey": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appInsightsModule')).outputs.appInsightsInstrumentationKey.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'appInsightsModule')).outputs.appInsightsInstrumentationKey.value]"
           },
           "language": {
             "value": "[variables('language')]"
@@ -215,7 +210,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.10.61.36676",
-              "templateHash": "13420738665403720981"
+              "templateHash": "16138593645198631912"
             }
           },
           "parameters": {
@@ -254,7 +249,7 @@
             {
               "type": "Microsoft.Web/sites",
               "apiVersion": "2022-03-01",
-              "name": "[parameters('appServiceName')]",
+              "name": "[toLower(format('app-{0}', parameters('appServiceName')))]",
               "location": "[parameters('location')]",
               "identity": {
                 "type": "SystemAssigned"
@@ -274,28 +269,28 @@
             {
               "type": "Microsoft.Web/sites/config",
               "apiVersion": "2022-03-01",
-              "name": "[format('{0}/{1}', parameters('appServiceName'), 'appsettings')]",
+              "name": "[format('{0}/{1}', toLower(format('app-{0}', parameters('appServiceName'))), 'appsettings')]",
               "properties": {
                 "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('appInsightsInstrumentationKey')]"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
+                "[resourceId('Microsoft.Web/sites', toLower(format('app-{0}', parameters('appServiceName'))))]"
               ]
             }
           ]
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appInsightsModule')]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appServicePlanModule')]",
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'appInsightsModule')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'appServicePlanModule')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', toLower(format('rg-{0}', variables('nameSuffix'))))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "logAnalyticsModule",
-      "resourceGroup": "[variables('resourceGroupName')]",
+      "resourceGroup": "[toLower(format('rg-{0}', variables('nameSuffix')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -306,7 +301,7 @@
             "value": "[parameters('location')]"
           },
           "logAnalyticsName": {
-            "value": "[variables('logAnalyticsName')]"
+            "value": "[variables('nameSuffix')]"
           },
           "language": {
             "value": "[variables('language')]"
@@ -319,7 +314,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.10.61.36676",
-              "templateHash": "10704820288659762609"
+              "templateHash": "4034223215877725501"
             }
           },
           "parameters": {
@@ -353,7 +348,7 @@
             {
               "type": "Microsoft.OperationalInsights/workspaces",
               "apiVersion": "2020-08-01",
-              "name": "[parameters('logAnalyticsName')]",
+              "name": "[toLower(format('la-{0}', parameters('logAnalyticsName')))]",
               "location": "[parameters('location')]",
               "tags": {
                 "displayName": "Log Analytics",
@@ -375,20 +370,20 @@
           "outputs": {
             "logAnalyticsWorkspaceID": {
               "type": "string",
-              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsName'))]"
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', toLower(format('la-{0}', parameters('logAnalyticsName'))))]"
             }
           }
         }
       },
       "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', toLower(format('rg-{0}', variables('nameSuffix'))))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "appInsightsModule",
-      "resourceGroup": "[variables('resourceGroupName')]",
+      "resourceGroup": "[toLower(format('rg-{0}', variables('nameSuffix')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -399,10 +394,10 @@
             "value": "[parameters('location')]"
           },
           "appInsightsName": {
-            "value": "[variables('appInsightsName')]"
+            "value": "[variables('nameSuffix')]"
           },
           "logAnalyticsWorkspaceID": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'logAnalyticsModule')).outputs.logAnalyticsWorkspaceID.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'logAnalyticsModule')).outputs.logAnalyticsWorkspaceID.value]"
           },
           "language": {
             "value": "[variables('language')]"
@@ -415,7 +410,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.10.61.36676",
-              "templateHash": "6412704949701566995"
+              "templateHash": "13062312230309702160"
             }
           },
           "parameters": {
@@ -448,7 +443,7 @@
             {
               "type": "Microsoft.Insights/components",
               "apiVersion": "2020-02-02",
-              "name": "[parameters('appInsightsName')]",
+              "name": "[toLower(format('ai-{0}', parameters('appInsightsName')))]",
               "location": "[parameters('location')]",
               "kind": "string",
               "tags": {
@@ -464,14 +459,14 @@
           "outputs": {
             "appInsightsInstrumentationKey": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName'))).InstrumentationKey]"
+              "value": "[reference(resourceId('Microsoft.Insights/components', toLower(format('ai-{0}', parameters('appInsightsName'))))).InstrumentationKey]"
             }
           }
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'logAnalyticsModule')]",
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, toLower(format('rg-{0}', variables('nameSuffix')))), 'Microsoft.Resources/deployments', 'logAnalyticsModule')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', toLower(format('rg-{0}', variables('nameSuffix'))))]"
       ]
     }
   ]

--- a/code/appService/bicep/main.bicep
+++ b/code/appService/bicep/main.bicep
@@ -14,16 +14,15 @@ var regionReference = {
   westus: 'wus'
   westus2: 'wus2'
 }
-var suffix = toLower('${baseName}-${environmentName}-${regionReference[location]}')
-var resourceGroupName = 'rg-${suffix}'
-var appServicePlanName = 'asp-${suffix}'
-var appServiceName = 'app-${suffix}'
-var appInsightsName = 'ai-${suffix}'
-var logAnalyticsName = 'la-${suffix}'
+var nameSuffix = toLower('${baseName}-${environmentName}-${regionReference[location]}')
 var language = 'Bicep'
 
+/* Since we are mismatching scopes with a deployment at subscription and resource at resource group
+ the main.bicep requires a resource Group deployed at the subscription scope, all modules will be at the resource Group Scop
+ */
+
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' ={
-  name: resourceGroupName
+  name: toLower('rg-${nameSuffix}')
   location: location
   tags:{
     Customer: 'FlavorsIaC'
@@ -36,7 +35,7 @@ module appServicePlan 'modules/appServicePlan.module.bicep' ={
   scope: resourceGroup
   params:{
     location: location
-    appServicePlanName: appServicePlanName
+    appServicePlanName: nameSuffix
     language: language
   }
 }
@@ -47,7 +46,7 @@ module appService 'modules/appService.module.bicep' ={
   params:{
     location: location
     appServicePlanID: appServicePlan.outputs.appServicePlanID
-    appServiceName: appServiceName
+    appServiceName: nameSuffix
     appInsightsInstrumentationKey: appInsights.outputs.appInsightsInstrumentationKey
     language: language
   }
@@ -58,7 +57,7 @@ module logAnalytics 'modules/logAnalytics.module.bicep' ={
   scope: resourceGroup
   params:{
     location: location
-    logAnalyticsName: logAnalyticsName
+    logAnalyticsName: nameSuffix
     language: language
   }
 }
@@ -68,7 +67,7 @@ module appInsights 'modules/appInsights.module.bicep' ={
   scope: resourceGroup
   params:{
     location: location
-    appInsightsName: appInsightsName
+    appInsightsName: nameSuffix
     logAnalyticsWorkspaceID: logAnalytics.outputs.logAnalyticsWorkspaceID
     language: language
   }

--- a/code/appService/bicep/modules/appInsights.module.bicep
+++ b/code/appService/bicep/modules/appInsights.module.bicep
@@ -9,7 +9,7 @@ param language string
 
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
-  name: appInsightsName
+  name: toLower('ai-${appInsightsName}')
   location: location
   kind: 'string'
   tags: {

--- a/code/appService/bicep/modules/appService.module.bicep
+++ b/code/appService/bicep/modules/appService.module.bicep
@@ -11,7 +11,7 @@ param language string
 
 
 resource appService 'Microsoft.Web/sites@2022-03-01' = {
-  name: appServiceName
+  name: toLower('app-${appServiceName}')
   location: location
   identity: {
     type: 'SystemAssigned'

--- a/code/appService/bicep/modules/appServicePlan.module.bicep
+++ b/code/appService/bicep/modules/appServicePlan.module.bicep
@@ -40,7 +40,7 @@ param appServicePlanSKU string = 'D1'
 param appServiceKind string = 'windows'
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
-  name: appServicePlanName
+  name: toLower('asp-${appServicePlanName}')
   location: location
   kind: appServiceKind
   sku: {

--- a/code/appService/bicep/modules/logAnalytics.module.bicep
+++ b/code/appService/bicep/modules/logAnalytics.module.bicep
@@ -8,7 +8,7 @@ param retentionDays int = 30
 param language string
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
-  name: logAnalyticsName
+  name: toLower('la-${logAnalyticsName}')
   location: location
   tags: {
     displayName: 'Log Analytics'

--- a/code/appService/terraform/main.tf
+++ b/code/appService/terraform/main.tf
@@ -41,7 +41,7 @@ locals {
 
 module "resource_group_module" {
   source                  = "./modules/resourceGroup"
-  resource_group_name     = "rg-${local.name_suffix}"
+  resource_group_name     = local.name_suffix
   resource_group_location = var.resource_group_location
   language                = var.language
 }
@@ -50,7 +50,7 @@ module "service_plan_module" {
   source                = "./modules/appServicePlan"
   resource_group_name   = module.resource_group_module.resource_group_name
   service_plan_location = module.resource_group_module.resource_group_location
-  service_plan_name     = lower("asp-${local.name_suffix}")
+  service_plan_name     = local.name_suffix
   language              = var.language
 }
 
@@ -58,7 +58,7 @@ module "log_analytics_module" {
   source                 = "./modules/logAnalytics"
   resource_group_name    = module.resource_group_module.resource_group_name
   log_analytics_location = module.resource_group_module.resource_group_location
-  log_analytics_name     = lower("la-${local.name_suffix}")
+  log_analytics_name     = local.name_suffix
   language               = var.language
 }
 
@@ -66,7 +66,7 @@ module "app_insights_module" {
   source                     = "./modules/appInsights"
   resource_group_name        = module.resource_group_module.resource_group_name
   app_insights_location      = module.resource_group_module.resource_group_location
-  app_insights_name          = lower("ai-${local.name_suffix}")
+  app_insights_name          = local.name_suffix
   language                   = var.language
   log_analytics_workspace_id = module.log_analytics_module.log_analytics_workspace_id
 }
@@ -75,7 +75,7 @@ module "app_service_module" {
   source                           = "./modules/appService"
   resource_group_name              = module.resource_group_module.resource_group_name
   app_service_location             = module.resource_group_module.resource_group_location
-  app_service_name                 = lower("app-${local.name_suffix}")
+  app_service_name                 = local.name_suffix
   language                         = var.language
   app_insights_instrumentation_key = module.app_insights_module.instrumentation_key
   service_plan_id                  = module.service_plan_module.service_plan_id

--- a/code/appService/terraform/modules/appInsights/main.tf
+++ b/code/appService/terraform/modules/appInsights/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_application_insights" "app_insights" {
-  name                = var.app_insights_name
+  name                = lower("ai-${var.app_insights_name}")
   location            = var.app_insights_location
   resource_group_name = var.resource_group_name
   application_type    = "web"

--- a/code/appService/terraform/modules/appService/main.tf
+++ b/code/appService/terraform/modules/appService/main.tf
@@ -1,6 +1,6 @@
 // Note this module will only work for Windows App Service Plans. AzureRM has a seperate provider for linux web apps
 resource "azurerm_windows_web_app" "app_service" {
-  name                = var.app_service_name
+  name                = lower("app-${var.app_service_name}")
   location            = var.app_service_location
   resource_group_name = var.resource_group_name
   tags = {

--- a/code/appService/terraform/modules/appServicePlan/main.tf
+++ b/code/appService/terraform/modules/appServicePlan/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_service_plan" "app_service_plan" {
-  name                = var.service_plan_name
+  name                = lower("asp-${var.service_plan_name}")
   location            = var.service_plan_location
   resource_group_name = var.resource_group_name
   os_type             = var.service_plan_os_type

--- a/code/appService/terraform/modules/logAnalytics/main.tf
+++ b/code/appService/terraform/modules/logAnalytics/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
-  name                = var.log_analytics_name
+  name                = lower("la-${var.log_analytics_name}")
   location            = var.log_analytics_location
   resource_group_name = var.resource_group_name
   sku                 = "PerGB2018"

--- a/code/appService/terraform/modules/resourceGroup/main.tf
+++ b/code/appService/terraform/modules/resourceGroup/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "resource_group" {
-  name     = var.resource_group_name
+  name     = lower("rg-${var.resource_group_name}")
   location = var.resource_group_location
   tags = {
     Language = var.language

--- a/code/storageAccount/ARM/main.json
+++ b/code/storageAccount/ARM/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.10.61.36676",
-      "templateHash": "15578430717780861700"
+      "templateHash": "6078318518771254026"
     }
   },
   "parameters": {
@@ -37,10 +37,8 @@
       "westus": "wus",
       "westus2": "wus2"
     },
-    "suffix": "[format('{0}-{1}', parameters('environmentName'), variables('regionReference')[parameters('location')])]",
-    "shortSufix": "[format('{0}{1}', parameters('environmentName'), variables('regionReference')[parameters('location')])]",
-    "resourceGroupName": "[format('rg-{0}-{1}', parameters('baseName'), variables('suffix'))]",
-    "storageAccountName": "[toLower(format('sa{0}{1}', parameters('baseName'), variables('shortSufix')))]",
+    "nameSuffix": "[format('{0}-{1}-{2}', parameters('baseName'), parameters('environmentName'), variables('regionReference')[parameters('location')])]",
+    "resourceGroupName": "[format('rg-{0}', variables('nameSuffix'))]",
     "language": "ARM"
   },
   "resources": [
@@ -69,7 +67,7 @@
             "value": "[parameters('location')]"
           },
           "storageAccountName": {
-            "value": "[variables('storageAccountName')]"
+            "value": "[variables('nameSuffix')]"
           },
           "language": {
             "value": "[variables('language')]"
@@ -82,7 +80,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.10.61.36676",
-              "templateHash": "9702551749707801282"
+              "templateHash": "6341193605553127306"
             }
           },
           "parameters": {
@@ -126,7 +124,7 @@
             {
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2021-06-01",
-              "name": "[parameters('storageAccountName')]",
+              "name": "[toLower(replace(format('sa{0}', parameters('storageAccountName')), '-', ''))]",
               "location": "[parameters('location')]",
               "identity": {
                 "type": "SystemAssigned"

--- a/code/storageAccount/Pulumi/Program.cs
+++ b/code/storageAccount/Pulumi/Program.cs
@@ -15,7 +15,7 @@ return await Pulumi.Deployment.RunAsync(() =>
     regionReference.Add("westus2", "wus2");
 
 
-    var suffix = config.Require("baseName") + "-" + config.Get("env") + "-" + regionReference[config.Require("location")];
+    var name_suffix = config.Require("baseName") + "-" + config.Get("env") + "-" + regionReference[config.Require("location")];
     var resourceGroupName = "rg-" + suffix;
     
 
@@ -33,7 +33,7 @@ return await Pulumi.Deployment.RunAsync(() =>
     var storageAccount = new StorageAccount("sa", new StorageAccountArgs
     {
         ResourceGroupName = resourceGroup.Name,
-        AccountName = "sa" + suffix.Replace("-", "").ToLower(),
+        AccountName = "sa" + name_suffix.Replace("-", "").ToLower(),
         Tags = {
                 ["Language"] = language
             },

--- a/code/storageAccount/bicep/main.bicep
+++ b/code/storageAccount/bicep/main.bicep
@@ -14,11 +14,13 @@ var regionReference = {
   westus: 'wus'
   westus2: 'wus2'
 }
-var suffix = '${environmentName}-${regionReference[location]}'
-var shortSufix= '${environmentName}${regionReference[location]}'
-var resourceGroupName = 'rg-${baseName}-${suffix}'
-var storageAccountName = toLower('sa${baseName}${shortSufix}')
+var nameSuffix = '${baseName}-${environmentName}-${regionReference[location]}'
+var resourceGroupName = 'rg-${nameSuffix}'
+
 var language = 'Bicep'
+/* Since we are mismatching scopes with a deployment at subscription and resource at resource group
+ the main.bicep requires a resource Group deployed at the subscription scope, all modules will be at the resource Group Scop
+ */
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' ={
   name: resourceGroupName
   location: location
@@ -33,7 +35,7 @@ module storageAccount 'modules/storageAccount.module.bicep' ={
   scope: resourceGroup
   params:{
     location: location
-    storageAccountName: storageAccountName
+    storageAccountName: nameSuffix
     language: language
   }
 }

--- a/code/storageAccount/bicep/modules/storageAccount.module.bicep
+++ b/code/storageAccount/bicep/modules/storageAccount.module.bicep
@@ -19,7 +19,7 @@ param language string
 param storageAccountType string = 'Standard_LRS'
 
 resource sa 'Microsoft.Storage/storageAccounts@2021-06-01' = {
-  name: storageAccountName
+  name: toLower(replace('sa${storageAccountName}','-',''))
   location: location
   identity: {
     type: 'SystemAssigned'

--- a/code/storageAccount/terraform/main.tf
+++ b/code/storageAccount/terraform/main.tf
@@ -42,7 +42,7 @@ locals {
 
 module "resource_group_module" {
   source                  = "./modules/resourceGroup"
-  resource_group_name     = "rg-${local.name_suffix}"
+  resource_group_name     = local.name_suffix
   resource_group_location = var.resource_group_location
   language                = var.language
 }
@@ -51,6 +51,6 @@ module "storate_account_module" {
   source                   = "./modules/storageAccount"
   resource_group_name      = module.resource_group_module.resource_group_name
   storage_account_location = module.resource_group_module.resource_group_location
-  storage_account_name     = lower("sa${replace(local.name_suffix, "-", "")}")
+  storage_account_name     = local.name_suffix
   language                 = var.language
 }

--- a/code/storageAccount/terraform/modules/resourceGroup/main.tf
+++ b/code/storageAccount/terraform/modules/resourceGroup/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "resource_group" {
-  name     = var.resource_group_name
+  name     = "rg-${var.resource_group_name}"
   location = var.resource_group_location
   tags = {
     Language = var.language

--- a/code/storageAccount/terraform/modules/storageAccount/main.tf
+++ b/code/storageAccount/terraform/modules/storageAccount/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "storage_account" {
-  name                     = var.storage_account_name
+  name                     = lower("sa${replace(var.storage_account_name, "-", "")}")
   resource_group_name      = var.resource_group_name
   location                 = var.storage_account_location
   account_tier             = var.storage_account_tier


### PR DESCRIPTION
Moving resource abbreviations to the modules since this will ensure consistency when reused within the same bicep file.